### PR TITLE
Compilation error fixes

### DIFF
--- a/contracts/CheckingClass.py
+++ b/contracts/CheckingClass.py
@@ -1,0 +1,22 @@
+import smartpy as sp
+
+
+def isContract(address):
+    sp.result(address < sp.address("tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU")) & (address > sp.address("KT18amZmM5W7qDWVt2pH6uj7sCEd3kbzLrHT"))
+
+def toLower(string):
+    return string
+    lower = sp.string("")
+    sp.for ch in string.items():
+        sp.if 'A' <= ch & ch <= 'Z':
+            lower += ch+32
+        sp.else:
+            lower += ch
+    return lower
+
+def isSafleIdValid(_registrarName):
+    VNinLowerCase = toLower(string=_registrarName)
+    length = sp.len(_registrarName)
+    sp.verify(4 <= length, "SafleId length should be greater than 3 characters")
+    sp.verify(length <= 16, "SafleId length should be less than 17 characters")
+    return True

--- a/contracts/CheckingContract.py
+++ b/contracts/CheckingContract.py
@@ -1,9 +1,0 @@
-import smartpy as sp
-
-
-class CheckingContract(sp.contract):
-    def __init__(self, _mainContractAddress):
-        self.init()
-
-    def isContract(self, address):
-        return (address < sp.address("tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU")) & (address > sp.address("KT18amZmM5W7qDWVt2pH6uj7sCEd3kbzLrHT"))

--- a/contracts/RegistrarStorage.py
+++ b/contracts/RegistrarStorage.py
@@ -2,11 +2,51 @@ import smartpy as sp
 
 
 class RegistrarStorage(sp.Contract):
-    def __init__(self, _mainContractAddress):
+    def __init__(self):
         self.init(
-            contractOwner=sp.sender,
-            mainContract=_mainContractAddress,
+            contractOwner=sp.address("tz1"),
+            mainContract=sp.address("tz1"),
+            resolveAddressFromSafleId=sp.map(),
+            auctionProcess=sp.map(),
+            coinAddressToSafleId=sp.map(),
+            OtherCoin=sp.map(),
+            isCoinMapped=sp.map(),
+            Registrars=sp.map(
+                tkey=sp.TAddress,
+                tvalue=sp.TRecord(
+                    isRegisteredRegistrar=sp.TBool,
+                    registrarName=sp.TString,
+                    registarAddress=sp.TAddress
+                )
+            ),
+            safleIdToCoinAddress=sp.map(
+                tkey=sp.TString,
+                tvalue=sp.TMap(sp.TNat, sp.TAddress)
+            ),
+            resolveUserAddress=sp.map(),
+            registrarNameToAddress=sp.map(),
+            isAddressTaken=sp.map(),
+            totalRegistrars=0,
+            totalSafleIdRegistered=0,
+            auctionContractAddress=sp.address("tz1"),
+            resolveOldSafleIdFromAddress=sp.map(
+                tkey=sp.TAddress,
+                tvalue=sp.TList(sp.TBytes)
+            ),
+            resolveOldSafleID=sp.map(),
+            totalRegistrarUpdates=sp.map(),
+            resolveOldRegistrarAddress=sp.map(
+                tkey=sp.TAddress,
+                tvalue=sp.TList(sp.TBytes)
+            ),
+            totalSafleIDCount=sp.map(),
+            unavailableSafleIds=sp.map()
         )
+
+    @sp.entry_point
+    def setOwner(self):
+        sp.verify(self.data.contractOwner == sp.address("tz1"), "Owner can be set only once.")
+        self.data.contractOwner = sp.sender
 
     def onlyOwner(self):
         sp.verify(self.data.contractOwner == sp.sender)
@@ -15,80 +55,74 @@ class RegistrarStorage(sp.Contract):
         sp.verify(self.data.mainContract == sp.sender)
 
     @sp.entry_point
-    def upgradeMainContractAddress(self, _mainContractAddress):
-        self.data.mainContract = _mainContractAddress
+    def upgradeMainContractAddress(self, params):
+        self.data.mainContract = params._mainContractAddress
 
     @sp.entry_point
     def registerRegistrar(self, _registrar, _registrarName):
-        regNameBytes = bytes(_registrarName)
-        self.data.Registrars[_registrar].isRegisteredRegistrar = True
-        self.data.Registrars[_registrar].registrarName = _registrarName
-        self.data.Registrars[_registrar].registarAddress = _registrar
+        regNameBytes = sp.pack(_registrarName)
+        self.data.Registrars[_registrar] = sp.record(
+            isRegisteredRegistrar=True,
+            registrarName=_registrarName,
+            registarAddress=_registrar
+        )
 
         self.data.registrarNameToAddress[regNameBytes] = _registrar
         self.data.isAddressTaken[_registrar] = True
         self.data.totalRegistrars += 1
-        return True
 
     @sp.entry_point
     def updateRegistrar(self, _registrar, _newRegistrarName):
-        newNameBytes = bytes(_newRegistrarName)
+        newNameBytes = sp.pack(_newRegistrarName)
 
         sp.verify(self.data.isAddressTaken[_registrar] == True)
-        sp.verify(
-            self.data.totalRegistrarUpdates[_registrar]+1 <= 5) #MAX_NAME_UPDATES
+        sp.verify(self.data.totalRegistrarUpdates[_registrar]+1 <= 5) #MAX_NAME_UPDATES
 
         registrarObject = self.data.Registrars[_registrar]
         oldName = registrarObject.registrarName
-        oldNameBytes = bytes(oldName)
-        self.data.registrarNameToAddress[oldNameBytes] = 0 #address(0x0)
+        oldNameBytes = sp.pack(oldName)
+        del self.data.registrarNameToAddress[oldNameBytes]
 
         self.data.resolveOldRegistrarAddress[_registrar].push(
-            bytes(self.data.Registrars[_registrar].registrarName))
+            sp.pack(self.data.Registrars[_registrar].registrarName))
 
         self.data.Registrars[_registrar].registrarName = _newRegistrarName
         self.data.Registrars[_registrar].registarAddress = _registrar
 
         self.data.registrarNameToAddress[newNameBytes] = _registrar
         self.data.totalRegistrarUpdates[_registrar] += 1
-        return True
 
-    @sp.entry_point
+    @sp.utils.view(sp.TAddress)
     def resolveRegistrarName(self, _name):
-        regNameBytes = bytes(_name)
-        sp.verify(self.data.registrarNameToAddress[regNameBytes] != 0)
-        return self.data.registrarNameToAddress[regNameBytes]
+        regNameBytes = sp.pack(_name)
+        sp.verify(self.data.registrarNameToAddress.contains(regNameBytes))
+        sp.result(self.data.registrarNameToAddress[regNameBytes])
   
     @sp.entry_point
     def registerSafleId(self, _registrar, _userAddress, _safleId):
-        sp.verify(self.data.isAddressTaken[_userAddress] ==
-                  False)
+        sp.verify(self.data.isAddressTaken[_userAddress] == False)
 
-        idBytes = bytes(_safleId)
+        idBytes = sp.pack(_safleId)
 
         self.data.resolveAddressFromSafleId[idBytes] = _userAddress
         self.data.isAddressTaken[_userAddress] = True
         self.data.resolveUserAddress[_userAddress] = _safleId
         self.data.totalSafleIdRegistered += 1
 
-        return True
-
     @sp.entry_point
     def updateSafleId(self, _registrar, _userAddress, _safleId):
-        sp.verify(
-            self.data.totalSafleIDCount[_userAddress]+1 <= 5) #MAX_NAME_UPDATES
-
+        sp.verify(self.data.totalSafleIDCount[_userAddress]+1 <= 5) #MAX_NAME_UPDATES
         sp.verify(self.data.isAddressTaken[_userAddress] == True)
         sp.verify(self.data.auctionProcess[_userAddress] == False)
 
-        idBytes = bytes(_safleId)
+        idBytes = sp.pack(_safleId)
 
         oldName = self.data.resolveUserAddress[_userAddress]
-        oldIdBytes = bytes(oldName)
+        oldIdBytes = sp.pack(oldName)
 
         self.data.unavailableSafleIds[oldName] = True
-        self.data.resolveAddressFromSafleId[oldIdBytes] = 0 #address(0x0)
-        self.data.oldSafleIds(_userAddress, oldIdBytes)
+        del self.data.resolveAddressFromSafleId[oldIdBytes]
+        self.oldSafleIds(_userAddress, oldIdBytes)
 
         self.data.resolveAddressFromSafleId[idBytes] = _userAddress
         self.data.resolveUserAddress[_userAddress] = _safleId
@@ -96,23 +130,21 @@ class RegistrarStorage(sp.Contract):
         self.data.totalSafleIDCount[_userAddress] += 1
         self.data.totalSafleIdRegistered += 1
 
-        return True
-    @sp.entry_point
+    @sp.utils.view(sp.TAddress)
     def resolveSafleId(self, _safleId):
-        idBytes = bytes(_safleId)
-        sp.verify(len(bytes(_safleId)) != 0)
-        sp.verify(
-            self.data.resolveAddressFromSafleId[idBytes] != 0) #address(0x0),)
-        return self.data.resolveAddressFromSafleId[idBytes]
+        idBytes = sp.pack(_safleId)
+        sp.verify(sp.len(sp.pack(_safleId)) != 0)
+        sp.verify(self.data.resolveAddressFromSafleId.contains(idBytes))
+        sp.result(self.data.resolveAddressFromSafleId[idBytes])
 
     @sp.entry_point
     def transferSafleId(self, _safleId, _oldOwner, _newOwner):
-        idBytes = bytes(_safleId)
+        idBytes = sp.pack(_safleId)
 
         sp.verify(self.data.isAddressTaken[_oldOwner] == True)
-        sp.verify(self.data.resolveAddressFromSafleId[idBytes] != 0) #address(0x0))
+        sp.verify(self.data.resolveAddressFromSafleId.contains(idBytes))
 
-        self.data.oldSafleIds(_oldOwner, idBytes)
+        self.oldSafleIds(_oldOwner, idBytes)
         self.data.isAddressTaken[_oldOwner] = False
 
         self.data.resolveAddressFromSafleId[idBytes] = _newOwner
@@ -120,89 +152,61 @@ class RegistrarStorage(sp.Contract):
         self.data.auctionProcess[_oldOwner] = False
         self.data.isAddressTaken[_newOwner] = True
         self.data.resolveUserAddress[_newOwner] = _safleId
-        return True
 
-    @sp.entry_point
     def oldSafleIds(self, _userAddress, _safleId):
         self.data.resolveOldSafleIdFromAddress[_userAddress].push(_safleId)
         self.data.resolveOldSafleID[_safleId] = _userAddress
-    @sp.entry_point
 
+    @sp.entry_point
     def setAuctionContract(self, _auctionAddress):
         self.data.auctionContractAddress = _auctionAddress
-        return True
 
     @sp.entry_point
     def auctionInProcess(self, _safleIdOwner, _safleId):
-        idBytes = bytes(_safleId)
+        idBytes = sp.pack(_safleId)
 
-        sp.verify(bytes(_safleId).length != 0)
-        sp.verify(
-            self.data.resolveAddressFromSafleId[idBytes] !=0) #address(0x0))
+        sp.verify(_safleId.length != 0)
+        sp.verify(self.data.resolveAddressFromSafleId.contains(idBytes))
         self.data.auctionProcess[_safleIdOwner] = True
-        return True
 
     @sp.entry_point
     def mapCoin(self, _indexnumber, _coinName, _aliasName, _registrar):
         sp.verify(self.data.OtherCoin[_indexnumber].isIndexMapped == False)
         sp.verify(self.data.isCoinMapped[_coinName] == False)
-        sp.verify(
-            self.data.Registrars[_registrar].registarAddress != 0) #address(0x0))
+        sp.verify(self.data.Registrars[_registrar].isRegisteredRegistrar)
 
         self.data.OtherCoin[_indexnumber].isIndexMapped = True
         self.data.OtherCoin[_indexnumber].aliasName = _aliasName
         self.data.OtherCoin[_indexnumber].coinName = _coinName
         self.data.isCoinMapped[_coinName] = True
-        return True
 
     @sp.entry_point
     def registerCoinAddress(self, _userAddress, _index, _address, _registrar):
         sp.verify(
-            self.data.Registrars[_registrar].registarAddress != 0) #address(0x0))
+            self.data.Registrars[_registrar].isRegisteredRegistrar)
         sp.verify(self.data.auctionProcess[_userAddress] == False)
         sp.verify(self.data.OtherCoin[_index].isIndexMapped == True)
 
         safleId = self.data.resolveUserAddress[_userAddress]
         self.data.safleIdToCoinAddress[safleId][_index] = _address
         self.data.coinAddressToSafleId[_address] = safleId
-        return True
 
     @sp.entry_point
     def updateCoinAddress(self, _userAddress, _index, _newAddress, _registrar):
-        sp.verify(self.data.Registrars[_registrar].registarAddress != address(
-            0x0))
+        sp.verify(self.data.Registrars[_registrar].isRegisteredRegistrar)
         sp.verify(self.data.auctionProcess[_userAddress] == False)
         sp.verify(self.data.OtherCoin[_index].isIndexMapped == True)
 
         safleId = self.data.resolveUserAddress[_userAddress]
-        previousAddress = self.data.safleIdToCoinAddress[safleId][_index]
-        sp.verify(len(previousAddress) > 0)
+        sp.verify(self.data.safleIdToCoinAddress[safleId].contains(_index))
 
         self.data.safleIdToCoinAddress[safleId][_index] = _newAddress
         self.data.coinAddressToSafleId[_newAddress] = safleId
-        return True
 
-    @sp.entry_point
+    @sp.utils.view(sp.TString)
     def coinAddressToId(self, _address):
-        return self.data.coinAddressToSafleId[_address]
+        sp.result(self.data.coinAddressToSafleId[_address])
 
-    @sp.entry_point
-    def idToCoinAddress(self, _safleId, _index):
-        return self.data.safleIdToCoinAddress[_safleId][_index]
-
-    @sp.add_test(name="SafleID Storage")
-    def test():
-        scenario = sp.test_scenario()
-        scenario.table_of_contents()
-        scenario.h1("Safle Storage")
-
-        # Initialize test admin addresses
-        contractOwner = sp.address("tz1-admin-1234")
-        seller = sp.address("tz1-seller-1234")
-        mainContract = sp.address("tz1-proxy-1234")
-
-        c1 = RegistrarStorage(mainContract)
-        scenario += c1
-
-        scenario += c1.registerRegistrar(_registrar=1,
-                                 _registrarName=seller).run(sender=mainContract)
+    @sp.utils.view(sp.TAddress)
+    def idToCoinAddress(self, params):
+        sp.result(self.data.safleIdToCoinAddress[params._safleId][params._index])


### PR DESCRIPTION
Issue: #1 

Directly running the main contract was calling the `registerRegistrar` entry_point. This was depending on many parts of the project.
All the errors coming in the way are resolved including mostly compilation errors, verifications, inter-contract calling, and the CheckingClass.py.

- Replace CheckingContract.py with CheckingClass.py. Since this class, mainly has utility functions and they all return something, their own class will be beneficiary. Just import them into the main contract and save the fees from the contract call.
- Only one test function is used in the main contract file, and `RegistrarStorage.py` was imported here.
- Added `setOwner` entry_point to initially set the contract owner.
- Completed the `registerRegistrar` entry_point code.
- Written the initial `RegistrarStorage` schema.
- Other minor fixes like
  - `sp.pack` is used to convert into bytes.
  - `del` is used to remove a map key-value pair.
  - `@sp.utils.view` is used to serve safle IDs.
  - `sp.result` is used to return the values.

However, there is still a lot of scope for more logical and security bug fixes. 