### PR TITLE
Utility functions for RegistrarStorage

### DIFF
--- a/contracts/RegistrarStorage.py
+++ b/contracts/RegistrarStorage.py
@@ -67,6 +67,9 @@ class RegistrarStorage(sp.Contract):
         sp.verify(~self.data.resolveAddressFromSafleId.contains(idBytes), "This SafleId is already registered.")
         sp.verify(~self.data.unavailableSafleIds.contains(_safleId), "SafleId is already used once, not available now")
 
+    def auctionContract(self):
+        sp.verify(sp.sender == self.data.auctionContractAddress)
+
     @sp.entry_point
     def upgradeMainContractAddress(self, params):
         self.data.mainContract = params._mainContractAddress

--- a/contracts/RegistrarStorage.py
+++ b/contracts/RegistrarStorage.py
@@ -70,6 +70,12 @@ class RegistrarStorage(sp.Contract):
     def auctionContract(self):
         sp.verify(sp.sender == self.data.auctionContractAddress)
 
+    def coinAddressCheck(self, _userAddress, _index, _registrar):
+        sp.verify(~self.data.Registrars.contains(_registrar), "Invalid Registrar")
+        sp.verify(self.data.OtherCoin.contains(_index), "This index number is not mapped.");
+        sp.if self.data.auctionProcess.contains(_userAddress):
+            sp.verify(~self.data.auctionProcess[_userAddress])
+
     @sp.entry_point
     def upgradeMainContractAddress(self, params):
         self.data.mainContract = params._mainContractAddress

--- a/contracts/RegistrarStorage.py
+++ b/contracts/RegistrarStorage.py
@@ -54,6 +54,11 @@ class RegistrarStorage(sp.Contract):
     def onlyMainContract(self):
         sp.verify(self.data.mainContract == sp.sender)
 
+    def registrarChecks(self, _registrarName):
+        regNameBytes = sp.pack(_registrarName)
+        sp.verify(~self.data.registrarNameToAddress.contains(regNameBytes), "Registrar name is already taken.")
+        sp.verify(~self.data.resolveAddressFromSafleId.contains(regNameBytes), "This Registrar name is already registered as an SafleID.")
+
     def safleIdChecks(self, _safleId, _registrar):
         idBytes = sp.pack(_safleId)
 

--- a/contracts/RegistrarStorage.py
+++ b/contracts/RegistrarStorage.py
@@ -54,6 +54,14 @@ class RegistrarStorage(sp.Contract):
     def onlyMainContract(self):
         sp.verify(self.data.mainContract == sp.sender)
 
+    def safleIdChecks(self, _safleId, _registrar):
+        idBytes = sp.pack(_safleId)
+
+        sp.verify(~self.data.Registrars.contains(_registrar), "Invalid Registrar.")
+        sp.verify(~self.data.registrarNameToAddress.contains(idBytes), "This SafleId is taken by a Registrar.")
+        sp.verify(~self.data.resolveAddressFromSafleId.contains(idBytes), "This SafleId is already registered.")
+        sp.verify(~self.data.unavailableSafleIds.contains(_safleId), "SafleId is already used once, not available now")
+
     @sp.entry_point
     def upgradeMainContractAddress(self, params):
         self.data.mainContract = params._mainContractAddress

--- a/contracts/RegistrarStorage.py
+++ b/contracts/RegistrarStorage.py
@@ -62,7 +62,7 @@ class RegistrarStorage(sp.Contract):
     def safleIdChecks(self, _safleId, _registrar):
         idBytes = sp.pack(_safleId)
 
-        sp.verify(~self.data.Registrars.contains(_registrar), "Invalid Registrar.")
+        sp.verify(self.data.Registrars.contains(_registrar), "Invalid Registrar.")
         sp.verify(~self.data.registrarNameToAddress.contains(idBytes), "This SafleId is taken by a Registrar.")
         sp.verify(~self.data.resolveAddressFromSafleId.contains(idBytes), "This SafleId is already registered.")
         sp.verify(~self.data.unavailableSafleIds.contains(_safleId), "SafleId is already used once, not available now")
@@ -71,7 +71,7 @@ class RegistrarStorage(sp.Contract):
         sp.verify(sp.sender == self.data.auctionContractAddress)
 
     def coinAddressCheck(self, _userAddress, _index, _registrar):
-        sp.verify(~self.data.Registrars.contains(_registrar), "Invalid Registrar")
+        sp.verify(self.data.Registrars.contains(_registrar), "Invalid Registrar")
         sp.verify(self.data.OtherCoin.contains(_index), "This index number is not mapped.");
         sp.if self.data.auctionProcess.contains(_userAddress):
             sp.verify(~self.data.auctionProcess[_userAddress])


### PR DESCRIPTION
#5 The four utility functions are added to use them easily in the further entry_point functions

- `registrarChecks` to perform the checks needed before adding any new registrar or updating any previous registrar
    - Will be used in `registerRegistrar` and `updateRegistrar`
- `safleIdChecks` to ensure that necessary conditions are satisfied before registering or updating SafleID
    - Will be used in `registerSafleId` and `updateSafleId`
- `auctionContract` to ensure that the caller is the Auction Contract
    - Will be used in `transferSafleId` and `auctionInProcess`
- `coinAddressCheck` to ensure that necessary conditions are satisfied before registering or updating the coin address
    - Will be used in `registerCoinAddress` and `updateCoinAddress`