### PR TITLE
Resolved deployment errors

### DIFF
--- a/contracts/CheckingContract.py
+++ b/contracts/CheckingContract.py
@@ -5,7 +5,7 @@ class CheckingContract(sp.Contract):
 
     @sp.global_lambda
     def isContract(address):
-        sp.result((address < sp.address("tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU")) & (address > sp.address("KT18amZmM5W7qDWVt2pH6uj7sCEd3kbzLrHT")))
+        sp.result((address < sp.address("tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU")) & (address >= sp.address("KT18amZmM5W7qDWVt2pH6uj7sCEd3kbzLrHT")))
 
     @sp.global_lambda
     def toLower(string):

--- a/contracts/RegistrarMain.py
+++ b/contracts/RegistrarMain.py
@@ -9,7 +9,7 @@ class RegistrarMain(checkingContract.CheckingContract):
             contractOwner=_ownerAddress,
             walletAddress=_walletAddress,
             safleIdRegStatus=False,
-            registrarStorageContractAddress=sp.address("tz1"),
+            registrarStorageContractAddress=sp.address("KT18amZmM5W7qDWVt2pH6uj7sCEd3kbzLrHT"),
             safleIdFees=sp.mutez(0),
             registrarFees=sp.mutez(0),
             storageContractAddress=False
@@ -31,11 +31,6 @@ class RegistrarMain(checkingContract.CheckingContract):
     def safleIdChecks(self, _safleId):
         sp.verify(sp.amount >= self.data.safleIdFees, "Registration fees not matched.")
         self.isSafleIdValid(_safleId)
-
-    @sp.entry_point
-    def setOwner(self):
-        sp.verify(self.data.contractOwner == sp.address("tz1"), "Owner can be set only once.")
-        self.data.contractOwner = sp.sender
 
     @sp.entry_point
     def setSafleIdFees(self, params):

--- a/contracts/RegistrarStorage.py
+++ b/contracts/RegistrarStorage.py
@@ -35,7 +35,7 @@ class RegistrarStorage(sp.Contract):
             isAddressTaken=sp.map(),
             totalRegistrars=0,
             totalSafleIdRegistered=0,
-            auctionContractAddress=sp.address("tz1"),
+            auctionContractAddress=sp.address("KT18amZmM5W7qDWVt2pH6uj7sCEd3kbzLrHT"),
             resolveOldSafleIdFromAddress=sp.map(
                 tkey=sp.TAddress,
                 tvalue=sp.TList(sp.TBytes)

--- a/contracts/Tests.py
+++ b/contracts/Tests.py
@@ -16,6 +16,10 @@ def test():
     wallet = sp.test_account("wallet")
     newWallet = sp.test_account("newWallet")
     user = sp.test_account("user")
+    oldSafleUser = sp.test_account("oldSafleUser")
+    bidder1 = sp.test_account("bidder1")
+    bidder2 = sp.test_account("bidder2")
+    bidder3 = sp.test_account("bidder3")
 
     scenario.h2("RegistrarMain Contract")
     mainContract = registrarMain.RegistrarMain(
@@ -29,9 +33,18 @@ def test():
     )
     scenario += storageContract
 
+    scenario.h2("Auction Contract")
+    auction = auctionContract.Auction(
+        _ownerAddress=owner.address, _storageContract=storageContract.address
+    )
+    scenario += auction
+
     scenario.h4("Setting Storage contract address in the Main contract")
     scenario += mainContract.setStorageContract(
         _registrarStorageContract=storageContract.address
+    ).run(sender=owner)
+    scenario += storageContract.setAuctionContract(
+        _auctionAddress=auction.address
     ).run(sender=owner)
 
     scenario.h2("Serial usage of Trasactions testing all entry_points")
@@ -107,86 +120,36 @@ def test():
         _mainContractAddress = newMainContract.address
     ).run(sender=owner)
 
-
-@sp.add_test(name="SafleID Auction")
-def test():
-    scenario = sp.test_scenario()
-    scenario.h1("Safle Auction")
-
-    owner = sp.test_account("owner")
-    registrar = sp.test_account("registrar")
-    wallet = sp.test_account("wallet")
-    oldSafleUser = sp.test_account("oldSafleUser")
-    bidder1 = sp.test_account("bidder1")
-    bidder2 = sp.test_account("bidder2")
-    bidder3 = sp.test_account("bidder3")
-
-    scenario.h2("RegistrarMain Contract")
-    mainContract = registrarMain.RegistrarMain(
-        _ownerAddress=owner.address, _walletAddress=wallet.address
-    )
-    scenario += mainContract
-
-    scenario.h2("RegistrarStorage Contract")
-    storageContract = registrarStorage.RegistrarStorage(
-        _ownerAddress=owner.address, _mainContractAddress=mainContract.address
-    )
-    scenario += storageContract
-
-    scenario.h2("Auction Contract")
-    auction = auctionContract.Auction(
-        _ownerAddress=owner.address, _storageContract=storageContract.address
-    )
-    scenario += auction
-
-    scenario.h4("Setting Contracts to each other")
-    mainContract.setStorageContract(
-        _registrarStorageContract=storageContract.address
-    ).run(sender=owner)
-    storageContract.setAuctionContract(
-        _auctionAddress=auction.address
-    ).run(sender=owner)
-
-    # Initial Setup
-    mainContract.setSafleIdFees(_amount=1000).run(sender=owner)
-    mainContract.setRegistrarFees(_amount=100000).run(sender=owner)
-    mainContract.registerRegistrar(_registrarName="registrar").run(
-        sender=registrar, amount=sp.mutez(100000)
-    )
-    mainContract.registerSafleId(
-        _safleId="oldSafleUser", _userAddress=oldSafleUser.address
-    ).run(sender=registrar, amount=sp.mutez(1000))
-
     scenario.h4("Starting an Auction")
     scenario += auction.auctionSafleId(
-        _safleId="oldsafleuser", _auctionSeconds=600
-    ).run(sender=oldSafleUser)
+        _safleId="user", _auctionSeconds=600
+    ).run(sender=user)
 
     scenario.h4("Bidding on the SafleID")
     scenario += auction.bidForSafleId(
-        _safleId="oldsafleuser"
+        _safleId="user"
     ).run(sender=bidder1, amount=sp.mutez(100))
     scenario += auction.bidForSafleId(
-        _safleId="oldsafleuser"
+        _safleId="user"
     ).run(sender=bidder2, amount=sp.mutez(200))
     scenario += auction.bidForSafleId(
-        _safleId="oldsafleuser"
+        _safleId="user"
     ).run(sender=bidder3, amount=sp.mutez(300))
     scenario += auction.bidForSafleId(
-        _safleId="oldsafleuser"
+        _safleId="user"
     ).run(sender=bidder1, amount=sp.mutez(1000))
 
     scenario.h4("Refunding the bidders except the winner")
-    scenario += auction.refundOtherBidders().run(sender=oldSafleUser)
+    scenario += auction.refundOtherBidders().run(sender=user)
 
     scenario.h4("Directly sending the safleID to the old user")
     scenario += auction.directlyTransferSafleId(
-        _safleId="oldsafleuser",
-        _newOwner=oldSafleUser.address
+        _safleId="user",
+        _newOwner=bidder2.address
     ).run(sender=bidder1)
 
     scenario.h4("Getting the array of all the bidders")
-    scenario.show(auction.arrayOfbidders(sp.record(_auctioner=oldSafleUser.address)))
+    scenario.show(auction.arrayOfbidders(sp.record(_auctioner=user.address)))
 
     scenario.h4("Getting the current bid rate of a bidder")
-    scenario.show(auction.getBidRate(sp.record(_auctioner=oldSafleUser.address, _bidder=bidder1.address)))
+    scenario.show(auction.getBidRate(sp.record(_auctioner=user.address, _bidder=bidder1.address)))


### PR DESCRIPTION
Closes #18

The contracts were not deploying because of some error causing lines in the code:
- We can't use `tz1` for any initial address, so used an other standard address for than
- Modified the `isContract()` function for that new address change
- Remove the obsolete `setOwner()` function, it's no more used.